### PR TITLE
Optional annotations

### DIFF
--- a/src/api/corpusConfig.test.ts
+++ b/src/api/corpusConfig.test.ts
@@ -58,8 +58,8 @@ describe("makeConfig", () => {
       format: "pdf",
       annotations: {
         datetime: {
-          datetimeFrom: "2000-01-01",
-          datetimeTo: "2023-12-31",
+          from: "2000-01-01",
+          to: "2023-12-31",
         },
       },
     });
@@ -136,8 +136,8 @@ describe("parseConfig", () => {
       sentenceSegmenter: "linebreaks",
       annotations: {
         datetime: {
-          datetimeFrom: "2000-01-01",
-          datetimeTo: "2023-12-31",
+          from: "2000-01-01",
+          to: "2023-12-31",
         },
         lexical_classes: true,
         saldo: true,

--- a/src/api/corpusConfig.test.ts
+++ b/src/api/corpusConfig.test.ts
@@ -124,7 +124,7 @@ describe("parseConfig", () => {
         { params: { out: "<text>:misc.dateto", value: "2023-12-31" } },
       ],
       export: {
-        annotations: ["swener.ne"],
+        annotations: ["<text>:readability.lix", "swener.ne"],
       },
     });
     const config = parseConfig(configYaml);
@@ -139,14 +139,14 @@ describe("parseConfig", () => {
           from: "2000-01-01",
           to: "2023-12-31",
         },
-        lexicalClasses: true,
-        msd: true,
+        lexicalClasses: false,
+        msd: false,
         readability: true,
-        saldo: true,
-        sensaldo: true,
+        saldo: false,
+        sensaldo: false,
         swener: true,
-        ud: true,
-        wsd: true,
+        ud: false,
+        wsd: false,
       },
     };
     expect(config).toStrictEqual(expected);

--- a/src/api/corpusConfig.test.ts
+++ b/src/api/corpusConfig.test.ts
@@ -145,7 +145,7 @@ describe("parseConfig", () => {
         saldo: false,
         sensaldo: false,
         swener: true,
-        ud: false,
+        syntax: false,
         wsd: false,
       },
     };

--- a/src/api/corpusConfig.test.ts
+++ b/src/api/corpusConfig.test.ts
@@ -12,12 +12,13 @@ describe("makeConfig", () => {
     const yaml = makeConfig("mink-abc123", {
       name: { swe: "Nyheter", eng: "News" },
       format: "txt",
+      annotations: {},
     });
     expect(yaml).toContain("id: mink-abc123");
     expect(yaml).toContain("swe: Nyheter");
     expect(yaml).toContain("eng: News");
     expect(yaml).toContain("importer: text_import:parse");
-    expect(yaml).toContain("- <token>:saldo.baseform2 as lemma");
+    expect(yaml).not.toContain("- <token>:saldo.baseform2 as lemma");
   });
 
   test("sets segmenter", () => {
@@ -25,6 +26,7 @@ describe("makeConfig", () => {
       name: { swe: "Nyheter", eng: "News" },
       format: "txt",
       sentenceSegmenter: "linebreaks",
+      annotations: {},
     });
     expect(yaml).toContain("sentence_segmenter: linebreaks");
   });
@@ -34,6 +36,7 @@ describe("makeConfig", () => {
       name: { swe: "Nyheter", eng: "News" },
       format: "xml",
       textAnnotation: "article",
+      annotations: {},
     });
     expect(yaml).toContain("text_annotation: article");
     expect(yaml).toContain("- article as text");
@@ -43,35 +46,22 @@ describe("makeConfig", () => {
     const yaml = makeConfig("mink-abc123", {
       name: { swe: "Nyheter", eng: "News" },
       format: "pdf",
+      annotations: {},
     });
     expect(yaml).toContain("- text");
     expect(yaml).toContain("- page:number");
-  });
-
-  test("requires complete timespan", () => {
-    const yamlFrom = () =>
-      makeConfig("mink-abc123", {
-        name: { swe: "Nyheter", eng: "News" },
-        format: "pdf",
-        datetimeFrom: "2024-02-01",
-      });
-    expect(yamlFrom).toThrowError();
-
-    const yamlTo = () =>
-      makeConfig("mink-abc123", {
-        name: { swe: "Nyheter", eng: "News" },
-        format: "pdf",
-        datetimeTo: "2024-02-01",
-      });
-    expect(yamlTo).toThrowError();
   });
 
   test("sets timespan info", () => {
     const yaml = makeConfig("mink-abc123", {
       name: { swe: "Nyheter", eng: "News" },
       format: "pdf",
-      datetimeFrom: "2000-01-01",
-      datetimeTo: "2023-12-31",
+      annotations: {
+        datetime: {
+          datetimeFrom: "2000-01-01",
+          datetimeTo: "2023-12-31",
+        },
+      },
     });
     expect(yaml).toContain("datetime_from: <text>:misc.datefrom");
     expect(yaml).toContain("datetime_to: <text>:misc.dateto");
@@ -85,7 +75,9 @@ describe("makeConfig", () => {
     const yaml = makeConfig("mink-abc123", {
       name: { swe: "Nyheter", eng: "News" },
       format: "pdf",
-      enableNer: true,
+      annotations: {
+        swener: true,
+      },
     });
     expect(yaml).toContain("- swener.ne:swener.name");
   });
@@ -142,9 +134,19 @@ describe("parseConfig", () => {
       description: { swe: "Senaste nytt", eng: "Latest news" },
       textAnnotation: "article",
       sentenceSegmenter: "linebreaks",
-      datetimeFrom: "2000-01-01",
-      datetimeTo: "2023-12-31",
-      enableNer: true,
+      annotations: {
+        datetime: {
+          datetimeFrom: "2000-01-01",
+          datetimeTo: "2023-12-31",
+        },
+        lexical_classes: true,
+        saldo: true,
+        sensaldo: true,
+        stanza: true,
+        swener: true,
+        wsd: true,
+        readability: true,
+      },
     };
     expect(config).toStrictEqual(expected);
   });
@@ -155,6 +157,7 @@ describe("validateConfig", () => {
     const options: ConfigOptions = {
       name: { swe: "Nyheter", eng: "News" },
       format: "xml",
+      annotations: {},
     };
 
     // Config can be handled

--- a/src/api/corpusConfig.test.ts
+++ b/src/api/corpusConfig.test.ts
@@ -139,13 +139,14 @@ describe("parseConfig", () => {
           from: "2000-01-01",
           to: "2023-12-31",
         },
-        lexical_classes: true,
+        lexicalClasses: true,
+        msd: true,
+        readability: true,
         saldo: true,
         sensaldo: true,
-        stanza: true,
         swener: true,
+        ud: true,
         wsd: true,
-        readability: true,
       },
     };
     expect(config).toStrictEqual(expected);

--- a/src/api/corpusConfig.ts
+++ b/src/api/corpusConfig.ts
@@ -29,7 +29,7 @@ export type AnnotationOptions = {
   saldo?: boolean;
   sensaldo?: boolean;
   swener?: boolean;
-  ud?: boolean;
+  syntax?: boolean;
   wsd?: boolean;
 };
 
@@ -102,7 +102,11 @@ export function makeConfig(id: string, options: ConfigOptions): string {
   }
 
   if (annotations.msd) {
-    config.export.annotations.push("<token>:stanza.msd", "<token>:stanza.pos");
+    config.export.annotations.push(
+      "<token>:stanza.msd",
+      "<token>:stanza.pos",
+      "<token>:stanza.ufeats",
+    );
   }
 
   if (annotations.readability) {
@@ -141,10 +145,9 @@ export function makeConfig(id: string, options: ConfigOptions): string {
     );
   }
 
-  if (annotations.ud) {
+  if (annotations.syntax) {
     config.export.annotations.push(
       "<token>:stanza.dephead_ref as dephead",
-      "<token>:stanza.ufeats",
       "<token>:stanza.deprel",
       "<token>:stanza.ref",
     );
@@ -206,7 +209,7 @@ export function emptyConfig(): ConfigOptions {
       readability: true,
       saldo: true,
       sensaldo: true,
-      ud: true,
+      syntax: true,
       msd: true,
       swener: false,
       wsd: true,
@@ -279,7 +282,7 @@ export function parseConfig(configYaml: string): ConfigOptions {
   );
   options.annotations.swener =
     config.export?.annotations?.includes("swener.ne");
-  options.annotations.ud = config.export?.annotations?.includes(
+  options.annotations.syntax = config.export?.annotations?.includes(
     "<token>:stanza.dephead_ref as dephead",
   );
   options.annotations.wsd =

--- a/src/api/corpusConfig.ts
+++ b/src/api/corpusConfig.ts
@@ -23,12 +23,13 @@ export type AnnotationOptions = {
     from: string;
     to: string;
   };
-  lexical_classes?: boolean;
+  lexicalClasses?: boolean;
+  msd?: boolean;
   readability?: boolean;
   saldo?: boolean;
   sensaldo?: boolean;
-  stanza?: boolean;
   swener?: boolean;
+  ud?: boolean;
   wsd?: boolean;
 };
 
@@ -91,13 +92,17 @@ export function makeConfig(id: string, options: ConfigOptions): string {
     "<text>:misc.id as _id",
   ];
 
-  if (annotations.lexical_classes) {
+  if (annotations.lexicalClasses) {
     config.export.annotations.push(
       "<token>:lexical_classes.blingbring",
       "<token>:lexical_classes.swefn",
       "<text>:lexical_classes.blingbring",
       "<text>:lexical_classes.swefn",
     );
+  }
+
+  if (annotations.msd) {
+    config.export.annotations.push("<token>:stanza.msd", "<token>:stanza.pos");
   }
 
   if (annotations.readability) {
@@ -124,17 +129,6 @@ export function makeConfig(id: string, options: ConfigOptions): string {
     );
   }
 
-  if (annotations.stanza) {
-    config.export.annotations.push(
-      "<token>:stanza.dephead_ref as dephead",
-      "<token>:stanza.ufeats",
-      "<token>:stanza.deprel",
-      "<token>:stanza.msd",
-      "<token>:stanza.pos",
-      "<token>:stanza.ref",
-    );
-  }
-
   // Enable named entity recognition.
   if (annotations.swener) {
     config.export.annotations.push(
@@ -144,6 +138,15 @@ export function makeConfig(id: string, options: ConfigOptions): string {
       "swener.ne:swener.type",
       "swener.ne:swener.subtype",
       "<sentence>:geo.geo_context as _geocontext",
+    );
+  }
+
+  if (annotations.ud) {
+    config.export.annotations.push(
+      "<token>:stanza.dephead_ref as dephead",
+      "<token>:stanza.ufeats",
+      "<token>:stanza.deprel",
+      "<token>:stanza.ref",
     );
   }
 
@@ -199,11 +202,12 @@ export function emptyConfig(): ConfigOptions {
     format: "txt",
     annotations: {
       datetime: undefined,
-      lexical_classes: true,
+      lexicalClasses: true,
       readability: true,
       saldo: true,
       sensaldo: true,
-      stanza: true,
+      ud: true,
+      msd: true,
       swener: false,
       wsd: true,
     },
@@ -259,8 +263,26 @@ export function parseConfig(configYaml: string): ConfigOptions {
   if (datetimeFrom && datetimeTo)
     options.annotations.datetime = { from: datetimeFrom, to: datetimeTo };
 
-  options.annotations.swener =
-    config.export?.annotations?.includes("swener.ne");
+  options.annotations.lexicalClasses = config.export.annotations.includes(
+    "<token>:lexical_classes.swefn",
+  );
+  options.annotations.msd =
+    config.export.annotations.includes("<token>:stanza.msd");
+  options.annotations.readability = config.export.annotations.includes(
+    "<text>:readability.lix",
+  );
+  options.annotations.saldo = config.export.annotations.includes(
+    "<token>:saldo.baseform2 as lemma",
+  );
+  options.annotations.sensaldo = config.export.annotations.includes(
+    "<token>:sensaldo.sentiment_score",
+  );
+  options.annotations.swener = config.export.annotations.includes("swener.ne");
+  options.annotations.ud = config.export.annotations.includes(
+    "<token>:stanza.dephead_ref as dephead",
+  );
+  options.annotations.wsd =
+    config.export.annotations.includes("<token>:wsd.sense");
 
   return options;
 }

--- a/src/api/corpusConfig.ts
+++ b/src/api/corpusConfig.ts
@@ -20,8 +20,8 @@ export type ConfigOptions = {
 
 export type AnnotationOptions = {
   datetime?: {
-    datetimeFrom: string;
-    datetimeTo: string;
+    from: string;
+    to: string;
   };
   lexical_classes?: boolean;
   readability?: boolean;
@@ -159,7 +159,7 @@ export function makeConfig(id: string, options: ConfigOptions): string {
         params: {
           out: "<text>:misc.datefrom",
           chunk: "<text>",
-          value: annotations.datetime.datetimeFrom,
+          value: annotations.datetime.from,
         },
       },
       {
@@ -167,7 +167,7 @@ export function makeConfig(id: string, options: ConfigOptions): string {
         params: {
           out: "<text>:misc.dateto",
           chunk: "<text>",
-          value: annotations.datetime.datetimeTo,
+          value: annotations.datetime.to,
         },
       },
     ];
@@ -257,7 +257,7 @@ export function parseConfig(configYaml: string): ConfigOptions {
     (a: any) => a.params.out == "<text>:misc.dateto",
   )?.params.value;
   if (datetimeFrom && datetimeTo)
-    options.annotations.datetime = { datetimeFrom, datetimeTo };
+    options.annotations.datetime = { from: datetimeFrom, to: datetimeTo };
 
   options.annotations.swener =
     config.export?.annotations?.includes("swener.ne");

--- a/src/api/corpusConfig.ts
+++ b/src/api/corpusConfig.ts
@@ -263,26 +263,27 @@ export function parseConfig(configYaml: string): ConfigOptions {
   if (datetimeFrom && datetimeTo)
     options.annotations.datetime = { from: datetimeFrom, to: datetimeTo };
 
-  options.annotations.lexicalClasses = config.export.annotations.includes(
+  options.annotations.lexicalClasses = config.export?.annotations?.includes(
     "<token>:lexical_classes.swefn",
   );
   options.annotations.msd =
-    config.export.annotations.includes("<token>:stanza.msd");
-  options.annotations.readability = config.export.annotations.includes(
+    config.export?.annotations?.includes("<token>:stanza.msd");
+  options.annotations.readability = config.export?.annotations?.includes(
     "<text>:readability.lix",
   );
-  options.annotations.saldo = config.export.annotations.includes(
+  options.annotations.saldo = config.export?.annotations?.includes(
     "<token>:saldo.baseform2 as lemma",
   );
-  options.annotations.sensaldo = config.export.annotations.includes(
+  options.annotations.sensaldo = config.export?.annotations?.includes(
     "<token>:sensaldo.sentiment_score",
   );
-  options.annotations.swener = config.export.annotations.includes("swener.ne");
-  options.annotations.ud = config.export.annotations.includes(
+  options.annotations.swener =
+    config.export?.annotations?.includes("swener.ne");
+  options.annotations.ud = config.export?.annotations?.includes(
     "<token>:stanza.dephead_ref as dephead",
   );
   options.annotations.wsd =
-    config.export.annotations.includes("<token>:wsd.sense");
+    config.export?.annotations?.includes("<token>:wsd.sense");
 
   return options;
 }

--- a/src/corpus/config/ConfigPanel.vue
+++ b/src/corpus/config/ConfigPanel.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { computed } from "vue";
+import { useI18n } from "vue-i18n";
 import useLocale from "@/i18n/locale.composable";
 import useConfig from "@/corpus/config/config.composable";
 import useCorpusIdParam from "@/corpus/corpusIdParam.composable";
@@ -8,6 +10,22 @@ import TerminalOutput from "@/components/TerminalOutput.vue";
 const corpusId = useCorpusIdParam();
 const { configOptions } = useConfig(corpusId);
 const { th } = useLocale();
+const { t } = useI18n();
+
+const annotationsSummary = computed(() => {
+  const annotations = configOptions.value?.annotations || {};
+  const selected: string[] = [];
+  if (annotations.lexicalClasses) selected.push("lexical_classes");
+  if (annotations.msd) selected.push("msd");
+  if (annotations.readability) selected.push("readability");
+  if (annotations.saldo) selected.push("saldo");
+  if (annotations.sensaldo) selected.push("sensaldo");
+  if (annotations.swener) selected.push("swener");
+  if (annotations.ud) selected.push("ud");
+  if (annotations.wsd) selected.push("wsd");
+  if (!selected.length) return "—";
+  return selected.map((key) => t(`annotations.${key}`)).join(", ");
+});
 </script>
 
 <template>
@@ -84,11 +102,9 @@ const { th } = useLocale();
         <td v-else>—</td>
       </tr>
       <tr>
-        <th>{{ $t("annotations.ner") }}</th>
+        <th>{{ $t("annotations") }}</th>
         <td v-if="configOptions">
-          {{
-            configOptions.annotations.swener ? $t("enabled") : $t("disabled")
-          }}
+          {{ annotationsSummary }}
         </td>
         <td v-else>—</td>
       </tr>

--- a/src/corpus/config/ConfigPanel.vue
+++ b/src/corpus/config/ConfigPanel.vue
@@ -72,19 +72,23 @@ const { th } = useLocale();
       </tr>
       <tr>
         <th>{{ $t("timespan") }}</th>
-        <td v-if="configOptions?.datetimeFrom || configOptions?.datetimeTo">
+        <td v-if="configOptions?.annotations.datetime">
           <span class="whitespace-nowrap">{{
-            configOptions.datetimeFrom
+            configOptions.annotations.datetime.from
           }}</span>
           –
-          <span class="whitespace-nowrap">{{ configOptions.datetimeTo }}</span>
+          <span class="whitespace-nowrap">{{
+            configOptions.annotations.datetime.to
+          }}</span>
         </td>
         <td v-else>—</td>
       </tr>
       <tr>
         <th>{{ $t("annotations.ner") }}</th>
         <td v-if="configOptions">
-          {{ configOptions.enableNer ? $t("enabled") : $t("disabled") }}
+          {{
+            configOptions.annotations.swener ? $t("enabled") : $t("disabled")
+          }}
         </td>
         <td v-else>—</td>
       </tr>

--- a/src/corpus/config/ConfigPanel.vue
+++ b/src/corpus/config/ConfigPanel.vue
@@ -21,7 +21,7 @@ const annotationsSummary = computed(() => {
   if (annotations.saldo) selected.push("saldo");
   if (annotations.sensaldo) selected.push("sensaldo");
   if (annotations.swener) selected.push("swener");
-  if (annotations.ud) selected.push("ud");
+  if (annotations.syntax) selected.push("syntax");
   if (annotations.wsd) selected.push("wsd");
   if (!selected.length) return "—";
   return selected.map((key) => t(`annotations.${key}`)).join(", ");

--- a/src/corpus/config/CorpusConfiguration.vue
+++ b/src/corpus/config/CorpusConfiguration.vue
@@ -110,7 +110,6 @@ async function submit(fields: Form) {
     textAnnotation: fields.textAnnotation,
     sentenceSegmenter: fields.sentenceSegmenter,
     annotations: {
-      // TODO Warn if only one is set
       datetime:
         fields.datetimeFrom && fields.datetimeTo
           ? {
@@ -261,12 +260,20 @@ async function submit(fields: Form) {
             type="date"
             :label="`${$t('timespan')}: ${$t('timespan_from')}`"
             :value="configOptions?.annotations.datetime?.from"
+            validation="onlyif:datetimeTo"
+            :validation-messages="{
+              onlyif: $t('config.datetime.validate_both'),
+            }"
           />
           <FormKit
             name="datetimeTo"
             type="date"
             :label="`${$t('timespan')}: ${$t('timespan_to')}`"
             :value="configOptions?.annotations.datetime?.to"
+            validation="onlyif:datetimeFrom"
+            :validation-messages="{
+              onlyif: $t('config.datetime.validate_both'),
+            }"
             :help="$t('timespan_help')"
           />
 

--- a/src/corpus/config/CorpusConfiguration.vue
+++ b/src/corpus/config/CorpusConfiguration.vue
@@ -44,7 +44,14 @@ type Form = {
   sentenceSegmenter: ConfigSentenceSegmenter;
   datetimeFrom: string;
   datetimeTo: string;
-  enableNer: boolean;
+  lexicalClasses: boolean;
+  msd: boolean;
+  readability: boolean;
+  saldo: boolean;
+  sensaldo: boolean;
+  swener: boolean;
+  ud: boolean;
+  wsd: boolean;
 };
 
 const configOptions = computed(getParsedConfig);
@@ -93,6 +100,7 @@ function getParsedConfig() {
 async function submit(fields: Form) {
   // If there is no previous config file, start from a minimal one.
   const configOld = configOptions.value || emptyConfig();
+
   // Merge new form values with existing config.
   const configNew: ConfigOptions = {
     ...configOld,
@@ -102,18 +110,23 @@ async function submit(fields: Form) {
     textAnnotation: fields.textAnnotation,
     sentenceSegmenter: fields.sentenceSegmenter,
     annotations: {
-      datetime: {
-        from: fields.datetimeFrom,
-        to: fields.datetimeTo,
-      },
+      // TODO Warn if only one is set
+      datetime:
+        fields.datetimeFrom && fields.datetimeTo
+          ? {
+              from: fields.datetimeFrom,
+              to: fields.datetimeTo,
+            }
+          : undefined,
       // TODO Configurable
-      lexical_classes: true,
-      readability: true,
-      saldo: true,
-      sensaldo: true,
-      stanza: true,
-      swener: fields.enableNer,
-      wsd: true,
+      lexicalClasses: fields.lexicalClasses,
+      msd: fields.msd,
+      readability: fields.readability,
+      saldo: fields.saldo,
+      sensaldo: fields.sensaldo,
+      swener: fields.swener,
+      ud: fields.ud,
+      wsd: fields.wsd,
     },
   };
 
@@ -259,16 +272,97 @@ async function submit(fields: Form) {
           />
 
           <LayoutSection :title="$t('annotations')">
+            <div class="prose">
+              <i18n-t tag="p" keypath="annotations.info">
+                <template #custom_config>
+                  <router-link
+                    :to="`/library/corpus/${corpusId}/config/custom`"
+                  >
+                    {{ $t("config.custom") }}
+                  </router-link>
+                </template>
+              </i18n-t>
+            </div>
+
+            <!-- Annotation options in some sort of order of usefulness -->
+
             <FormKit
-              name="enableNer"
-              :label="$t('annotations.ner')"
-              :value="configOptions?.annotations.swener"
+              name="saldo"
+              :label="$t('annotations.saldo')"
+              :value="configOptions?.annotations.saldo"
               type="checkbox"
-              :help="$t('annotations.ner.help')"
+              :help="$t('annotations.saldo.help')"
+            >
+              <template #help>
+                <i18n-t
+                  keypath="annotations.saldo.help"
+                  tag="div"
+                  class="formkit-help"
+                >
+                  <template #saldo>
+                    <a :href="$t('annotations.saldo.saldo_url')" target="_blank"
+                      >SALDO</a
+                    >
+                  </template>
+                </i18n-t>
+              </template>
+            </FormKit>
+
+            <FormKit
+              name="msd"
+              :label="$t('annotations.msd')"
+              :value="configOptions?.annotations.msd"
+              type="checkbox"
+              :help="$t('annotations.msd.help')"
             />
 
-            <!-- eslint-disable-next-line vue/no-v-html -->
-            <div class="prose" v-html="$t('annotations.info')" />
+            <FormKit
+              name="ud"
+              :label="$t('annotations.ud')"
+              :value="configOptions?.annotations.ud"
+              type="checkbox"
+              :help="$t('annotations.ud.help')"
+            />
+
+            <FormKit
+              name="readability"
+              :label="$t('annotations.readability')"
+              :value="configOptions?.annotations.readability"
+              type="checkbox"
+              :help="$t('annotations.readability.help')"
+            />
+
+            <FormKit
+              name="wsd"
+              :label="$t('annotations.wsd')"
+              :value="configOptions?.annotations.wsd"
+              type="checkbox"
+              :help="$t('annotations.wsd.help')"
+            />
+
+            <FormKit
+              name="sensaldo"
+              :label="$t('annotations.sensaldo')"
+              :value="configOptions?.annotations.sensaldo"
+              type="checkbox"
+              :help="$t('annotations.sensaldo.help')"
+            />
+
+            <FormKit
+              name="lexicalClasses"
+              :label="$t('annotations.lexical_classes')"
+              :value="configOptions?.annotations.lexicalClasses"
+              type="checkbox"
+              :help="$t('annotations.lexical_classes.help')"
+            />
+
+            <FormKit
+              name="swener"
+              :label="$t('annotations.swener')"
+              :value="configOptions?.annotations.swener"
+              type="checkbox"
+              :help="$t('annotations.swener.help')"
+            />
           </LayoutSection>
         </LayoutSection>
       </FormKit>

--- a/src/corpus/config/CorpusConfiguration.vue
+++ b/src/corpus/config/CorpusConfiguration.vue
@@ -273,7 +273,7 @@ async function submit(fields: Form) {
 
           <LayoutSection :title="$t('annotations')">
             <div class="prose">
-              <i18n-t tag="p" keypath="annotations.info">
+              <i18n-t tag="p" keypath="annotations.info" scope="global">
                 <template #custom_config>
                   <router-link
                     :to="`/library/corpus/${corpusId}/config/custom`"
@@ -295,8 +295,9 @@ async function submit(fields: Form) {
             >
               <template #help>
                 <i18n-t
-                  keypath="annotations.saldo.help"
                   tag="div"
+                  keypath="annotations.saldo.help"
+                  scope="global"
                   class="formkit-help"
                 >
                   <template #saldo>

--- a/src/corpus/config/CorpusConfiguration.vue
+++ b/src/corpus/config/CorpusConfiguration.vue
@@ -118,7 +118,6 @@ async function submit(fields: Form) {
               to: fields.datetimeTo,
             }
           : undefined,
-      // TODO Configurable
       lexicalClasses: fields.lexicalClasses,
       msd: fields.msd,
       readability: fields.readability,

--- a/src/corpus/config/CorpusConfiguration.vue
+++ b/src/corpus/config/CorpusConfiguration.vue
@@ -50,7 +50,7 @@ type Form = {
   saldo: boolean;
   sensaldo: boolean;
   swener: boolean;
-  ud: boolean;
+  syntax: boolean;
   wsd: boolean;
 };
 
@@ -124,7 +124,7 @@ async function submit(fields: Form) {
       saldo: fields.saldo,
       sensaldo: fields.sensaldo,
       swener: fields.swener,
-      ud: fields.ud,
+      syntax: fields.syntax,
       wsd: fields.wsd,
     },
   };
@@ -317,11 +317,11 @@ async function submit(fields: Form) {
             />
 
             <FormKit
-              name="ud"
-              :label="$t('annotations.ud')"
-              :value="configOptions?.annotations.ud"
+              name="syntax"
+              :label="$t('annotations.syntax')"
+              :value="configOptions?.annotations.syntax"
               type="checkbox"
-              :help="$t('annotations.ud.help')"
+              :help="$t('annotations.syntax.help')"
             />
 
             <FormKit

--- a/src/corpus/config/CorpusConfiguration.vue
+++ b/src/corpus/config/CorpusConfiguration.vue
@@ -260,6 +260,7 @@ async function submit(fields: Form) {
             type="date"
             :label="`${$t('timespan')}: ${$t('timespan_from')}`"
             :value="configOptions?.annotations.datetime?.from"
+            :max="(value as Form).datetimeTo"
             validation="onlyif:datetimeTo"
             :validation-messages="{
               onlyif: $t('config.datetime.validate_both'),
@@ -270,6 +271,7 @@ async function submit(fields: Form) {
             type="date"
             :label="`${$t('timespan')}: ${$t('timespan_to')}`"
             :value="configOptions?.annotations.datetime?.to"
+            :min="(value as Form).datetimeFrom"
             validation="onlyif:datetimeFrom"
             :validation-messages="{
               onlyif: $t('config.datetime.validate_both'),

--- a/src/corpus/config/CorpusConfiguration.vue
+++ b/src/corpus/config/CorpusConfiguration.vue
@@ -101,9 +101,20 @@ async function submit(fields: Form) {
     format: fields.format,
     textAnnotation: fields.textAnnotation,
     sentenceSegmenter: fields.sentenceSegmenter,
-    datetimeFrom: fields.datetimeFrom,
-    datetimeTo: fields.datetimeTo,
-    enableNer: fields.enableNer,
+    annotations: {
+      datetime: {
+        from: fields.datetimeFrom,
+        to: fields.datetimeTo,
+      },
+      // TODO Configurable
+      lexical_classes: true,
+      readability: true,
+      saldo: true,
+      sensaldo: true,
+      stanza: true,
+      swener: fields.enableNer,
+      wsd: true,
+    },
   };
 
   try {
@@ -237,13 +248,13 @@ async function submit(fields: Form) {
             name="datetimeFrom"
             type="date"
             :label="`${$t('timespan')}: ${$t('timespan_from')}`"
-            :value="configOptions?.datetimeFrom"
+            :value="configOptions?.annotations.datetime?.from"
           />
           <FormKit
             name="datetimeTo"
             type="date"
             :label="`${$t('timespan')}: ${$t('timespan_to')}`"
-            :value="configOptions?.datetimeTo"
+            :value="configOptions?.annotations.datetime?.to"
             :help="$t('timespan_help')"
           />
 
@@ -251,7 +262,7 @@ async function submit(fields: Form) {
             <FormKit
               name="enableNer"
               :label="$t('annotations.ner')"
-              :value="configOptions?.enableNer"
+              :value="configOptions?.annotations.swener"
               type="checkbox"
               :help="$t('annotations.ner.help')"
             />

--- a/src/corpus/createCorpus.composable.ts
+++ b/src/corpus/createCorpus.composable.ts
@@ -9,6 +9,7 @@ import {
   makeConfig,
   type FileFormat,
   type ConfigOptions,
+  emptyConfig,
 } from "@/api/corpusConfig";
 import type { MinkResponse, ProgressHandler } from "@/api/api.types";
 import useCreateResource from "@/resource/createResource.composable";
@@ -37,7 +38,8 @@ export default function useCreateCorpus() {
     const format = getFilenameExtension(files[0]?.name) as FileFormat;
 
     // Create a minimal config.
-    const config: ConfigOptions = {
+    const config = {
+      ...emptyConfig(),
       name: { swe: corpusId, eng: corpusId },
       format,
     };
@@ -87,6 +89,7 @@ export default function useCreateCorpus() {
     textAnnotation?: string,
   ): Promise<string | undefined> {
     const config = {
+      ...emptyConfig(),
       name: { swe: name, eng: name },
       description: { swe: description, eng: description },
       format,

--- a/src/formkit.ts
+++ b/src/formkit.ts
@@ -5,8 +5,9 @@ import type { FormKitNode, FormKitExtendableSchemaRoot } from "@formkit/core";
 
 // Configure FormKit
 export const formkitConfig = defaultConfig({
-  plugins: [addAsteriskPlugin],
   locales: { en, sv },
+  plugins: [addAsteriskPlugin],
+  rules: { onlyif },
 });
 
 /** A Formkit plugin that adds a red asterisk to required fields. */
@@ -35,3 +36,21 @@ function addAsteriskPlugin(node: FormKitNode) {
     };
   });
 }
+
+/** Validation rule to require that all or none of a group of fields are set. */
+function onlyif(node: FormKitNode, othersComma: string) {
+  const parent = node.at("$parent") as FormKitNode<Record<string, any>>;
+  if (!parent?.value) {
+    console.error("onlyif rule missing parent");
+    return true;
+  }
+
+  for (const other of othersComma.split(",")) {
+    if (other in parent.value) {
+      if (!!parent.value[other] != !!node.value) return false;
+    }
+  }
+  return true;
+}
+
+onlyif.skipEmpty = false;

--- a/src/formkit.ts
+++ b/src/formkit.ts
@@ -46,9 +46,8 @@ function onlyif(node: FormKitNode, othersComma: string) {
   }
 
   for (const other of othersComma.split(",")) {
-    if (other in parent.value) {
-      if (!!parent.value[other] != !!node.value) return false;
-    }
+    if (other in parent.value && !!parent.value[other] != !!node.value)
+      return false;
   }
   return true;
 }

--- a/src/i18n/locales/en.yaml
+++ b/src/i18n/locales/en.yaml
@@ -231,8 +231,8 @@ annotations.sensaldo: Sentiment
 annotations.sensaldo.help: Tags tokens as positive/neutral/negative.
 annotations.swener: Named entities and geotagging
 annotations.swener.help: Named entity recognition (NER) finds individuals, places, dates and more in your texts using SweNER. However, it significantly slows down processing. Enabling NER also enables geotagging and, in turn, the map feature in Korp.
-annotations.ud: Universal Dependencies
-annotations.ud.help: Syntactic analysis using Stanza.
+annotations.syntax: Dependencies
+annotations.syntax.help: Syntactic analysis using Stanza.
 annotations.wsd: Word sense disambiguation
 annotations.wsd.help: Using SALDO.
 admin.page.subtitle: Administration

--- a/src/i18n/locales/en.yaml
+++ b/src/i18n/locales/en.yaml
@@ -204,6 +204,7 @@ config.custom: Custom config
 config.custom.help: Mink uses {sparv}, a modular and configurable pipeline for text analysis, to process your corpus. The standard configuration form only exposes a few of the available Sparv options. On this page, you can view and submit your own config file, written in the YAML format. Please refer to the Sparv documentation on {topic} for more information.
 config.custom.upload.caution: Please note that submitting an invalid config file may cause unexpected behaviour.
 config.custom.upload.overwrite: Saving the standard configuration form may overwrite your custom config.
+config.datetime.validate_both: Both or none of these dates must be set.
 config.format.help: Select the file format of the source texts. All files must be of the selected format.
 config.format.note.pdf: The PDF file format is primarily designed for display. Please note that extracting text from them can sometimes give unsatisfactory results. Performing OCR on scanned documents is (currently) outside the scope of Mink.
 config.text_annotation: Text element

--- a/src/i18n/locales/en.yaml
+++ b/src/i18n/locales/en.yaml
@@ -217,27 +217,24 @@ timespan_from: From
 timespan_to: To
 edit: Edit
 annotations: Annotations
-annotations.ner: Named entity recognition and geotagging
-annotations.ner.help: Named entity recognition (NER) finds individuals, places, dates and more in your texts. However, it significantly slows down processing. Enabling NER also enables geotagging and, in turn, the map feature in Korp.
-annotations.info: |
-  <p>
-    We are working on making it possible to choose among more methods, annotations and models to be used in the analysis.
-    At this time, apart from the options above, the analysis will enrich the texts with the following annotations:</p>
-  <ul>
-    <li>Part-of-speech tags</li>
-    <li>Morphosyntactic tags</li>
-    <li>Base form</li>
-    <li>Lemgram</li>
-    <li>Saldo sense</li>
-    <li>Compound word analysis</li>
-    <li>Dependency parsing</li>
-    <li>Sentiment analysis</li>
-    <li>Lexical classes from SweFN and Blingbring</li>
-    <li>Readability values per text</li>
-  </ul>
-  <p>You can find some more information about the annotations in the 
-    <a href="https://spraakbanken.gu.se/sparv/#/user-manual/available-analyses">Sparv documentation</a>.
-  </p>
+annotations.info: Listed for selection here are some of the available analyses. For more detailed configuration, please use the {custom_config} page.
+annotations.lexical_classes: Lexical classes
+annotations.lexical_classes.help: Maps words to Blingbring and the Swedish FrameNet (SweFN).
+annotations.msd: Morphology
+annotations.msd.help: Parts-of-speech and morphosyntactic features.
+annotations.readability: Readability
+annotations.readability.help: Computes the readability measures LIX, OVIX and NK.
+annotations.saldo: Lemmatization
+annotations.saldo.help: Uses the {saldo} resource for finding baseforms, inflection patterns and compound words.
+annotations.saldo.saldo_url: https://spraakbanken.gu.se/en/resources/saldo
+annotations.sensaldo: Sentiment
+annotations.sensaldo.help: Tags tokens as positive/neutral/negative.
+annotations.swener: Named entities and geotagging
+annotations.swener.help: Named entity recognition (NER) finds individuals, places, dates and more in your texts using SweNER. However, it significantly slows down processing. Enabling NER also enables geotagging and, in turn, the map feature in Korp.
+annotations.ud: Universal Dependencies
+annotations.ud.help: Syntactic analysis using Stanza.
+annotations.wsd: Word sense disambiguation
+annotations.wsd.help: Using SALDO.
 admin.page.subtitle: Administration
 admin.goto: Shortcuts
 admin.resources.help: In this administrative listing, you need to load detailed information manually, because loading everything takes a long time.

--- a/src/i18n/locales/en.yaml
+++ b/src/i18n/locales/en.yaml
@@ -219,7 +219,7 @@ edit: Edit
 annotations: Annotations
 annotations.info: Listed for selection here are some of the available analyses. For more detailed configuration, please use the {custom_config} page.
 annotations.lexical_classes: Lexical classes
-annotations.lexical_classes.help: Maps words to Blingbring and the Swedish FrameNet (SweFN).
+annotations.lexical_classes.help: Maps units to Blingbring and the Swedish FrameNet (SweFN).
 annotations.msd: Morphology
 annotations.msd.help: Parts-of-speech and morphosyntactic features.
 annotations.readability: Readability

--- a/src/i18n/locales/sv.yaml
+++ b/src/i18n/locales/sv.yaml
@@ -205,6 +205,7 @@ config.custom: Egen config
 config.custom.help: Mink använder {sparv}, en modulär och konfigurerbar pipeline för textanalys, för att processa korpusen. Det vanliga formuläret visar endast en liten del av alla inställningar. På den här sidan kan du undersöka den faktiska configfilen och ladda upp en egen, i formatet YAML. Använd Sparvdokumentationens avsnitt {topic} för att tolka filens struktur.
 config.custom.upload.caution: Notera att en ogiltig configfil kan leda till oväntat beteende.
 config.custom.upload.overwrite: Om du sparar i det vanliga formuläret igen kan den egna configen skrivas över.
+config.datetime.validate_both: Båda eller inget av dessa datum måste anges.
 config.format.help: Ange vilket filformat källtexterna har. Alla filer måste ha det valda formatet.
 config.format.note.pdf: PDF-formatet är byggt främst för visuell presentation. Text som extraheras från PDF-filer kan ibland ge bristfälliga resultat. OCR-behandling av scannade dokument är (för närvarande) inget som Mink stödjer.
 config.text_annotation: Textelement

--- a/src/i18n/locales/sv.yaml
+++ b/src/i18n/locales/sv.yaml
@@ -220,7 +220,7 @@ edit: Redigera
 annotations: Annotationer
 annotations.info: Här listas tillval för några av de tillgängliga analyserna. Mer utförlig konfiguration kan göras på sidan {custom_config}.
 annotations.lexical_classes: Lexikala klasser
-annotations.lexical_classes.help: Mappar ord till Blingbring och Svenskt frasnät (SweFN).
+annotations.lexical_classes.help: Mappar till Blingbring och Svenskt frasnät (SweFN).
 annotations.msd: Morfologi
 annotations.msd.help: Ordklass och morfosyntaktiska egenskaper.
 annotations.readability: Läsbarhet

--- a/src/i18n/locales/sv.yaml
+++ b/src/i18n/locales/sv.yaml
@@ -218,28 +218,24 @@ timespan_from: Från
 timespan_to: Till
 edit: Redigera
 annotations: Annotationer
-annotations.ner: Namngivna entiteter och geotaggning
-annotations.ner.help: Namngivna entitetsigenkänning (named entity recognition, NER) hittar personer, platser, datum och liknande i dina texter. Däremot tar analysen ganska lång tid. När NER är aktiverat görs även geotaggning, vilket aktiverar kartfunktionen i Korp.
-annotations.info: |
-  <p>
-    Vi jobbar på möjligheten att välja bland fler analysmetoder, annotationer och modeller.
-    Förutom alternativen ovan kommer analysen automatiskt att berika texten med följande annotationer:
-  </p>
-  <ul>
-    <li>ordklasstaggar</li>
-    <li>morfosyntaktiska taggar</li>
-    <li>grundform</li>
-    <li>lemgram</li>
-    <li>saldo-betydelse</li>
-    <li>sammansättningsanalys</li>
-    <li>dependensparsning</li>
-    <li>attitydanalys</li>
-    <li>lexikala klasser från SweFN och Blingbring</li>
-    <li>läsbarhetsvärden för hela texten</li>
-  </ul>
-  <p>Du kan hitta lite mer info om annotationerna i
-    <a href="https://spraakbanken.gu.se/sparv/#/user-manual/available-analyses">Sparvs dokumentation</a>.
-  </p>
+annotations.info: Här listas tillval för några av de tillgängliga analyserna. Mer utförlig konfiguration kan göras på sidan {custom_config}.
+annotations.lexical_classes: Lexikala klasser
+annotations.lexical_classes.help: Mappar ord till Blingbring och Svenskt frasnät (SweFN).
+annotations.msd: Morfologi
+annotations.msd.help: Ordklass och morfosyntaktiska egenskaper.
+annotations.readability: Läsbarhet
+annotations.readability.help: Räknar ut läsbarhetsvärdena LIX, OVIX och NK.
+annotations.saldo: Lemmatisering
+annotations.saldo.help: Använder resursen {saldo} för att finna grundformer, böjningsmönster och sammansatta ord.
+annotations.saldo.saldo_url: https://spraakbanken.gu.se/resurser/saldo
+annotations.sensaldo: Sentiment
+annotations.sensaldo.help: Taggar token som positiv/neutral/negativ.
+annotations.swener: Namngivna entiteter och geotaggning
+annotations.swener.help: Namngivna entitetsigenkänning (named entity recognition, NER) hittar personer, platser, datum och liknande i dina texter genom att använda SweNER. Däremot tar analysen ganska lång tid. När NER är aktiverat görs även geotaggning, vilket aktiverar kartfunktionen i Korp.
+annotations.ud: Universal Dependencies
+annotations.ud.help: Syntaxanalys med Stanza.
+annotations.wsd: Disambiguering
+annotations.wsd.help: Använder SALDO.
 admin.page.subtitle: Administration
 admin.goto: Genvägar
 admin.resources.help: I denna administrativa resurslista behöver du ladda in detaljerad resursinformation manuellt, eftersom det tar lång tid att ladda allt.

--- a/src/i18n/locales/sv.yaml
+++ b/src/i18n/locales/sv.yaml
@@ -232,10 +232,10 @@ annotations.sensaldo: Sentiment
 annotations.sensaldo.help: Taggar token som positiv/neutral/negativ.
 annotations.swener: Namngivna entiteter och geotaggning
 annotations.swener.help: Namngivna entitetsigenkänning (named entity recognition, NER) hittar personer, platser, datum och liknande i dina texter genom att använda SweNER. Däremot tar analysen ganska lång tid. När NER är aktiverat görs även geotaggning, vilket aktiverar kartfunktionen i Korp.
-annotations.ud: Universal Dependencies
-annotations.ud.help: Syntaxanalys med Stanza.
-annotations.wsd: Disambiguering
-annotations.wsd.help: Använder SALDO.
+annotations.syntax: Dependenser
+annotations.syntax.help: Syntaxanalys med Stanza.
+annotations.wsd: Betydelser
+annotations.wsd.help: Ordbetydelsedisambiguering med SALDO.
 admin.page.subtitle: Administration
 admin.goto: Genvägar
 admin.resources.help: I denna administrativa resurslista behöver du ladda in detaljerad resursinformation manuellt, eftersom det tar lång tid att ladda allt.


### PR DESCRIPTION
Introduces options to deselect groups of the default annotations.

Notes for review:
- See `corpusConfig.ts` for mapping between form checkboxes and `export.annotations` items
  - [x] Does the grouping make sense?
  - [x] Are there any combinations of annotations that doesn't make sense?
  - [x] Are the descriptions accurate? (`en.yaml`, `sv.yaml`)
- Note that the stored config is parsed in order to identify which checkboxes should be rendered selected, and it just checks for one of the items in each group. This aligns with the existing condition that saving the config form may overwrite any "custom config", so I think it's safe (= will not surprise users).

Remaining tasks:
- [x] Fix the `// TODO Warn if only one is set` for the date range

![optional-annotations](https://github.com/user-attachments/assets/613df519-9d66-4fbf-aa9c-edabd19f1009)
